### PR TITLE
docs: remove yarn install instruction from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The _JSON Viewer_ is a web app designed to validate, format, and visualize JSON 
 
 ### Installation
 ```
-npm install (or yarn install)
+npm install
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- Remove the incorrect `or yarn install` text from README.
- Keep install instructions npm-only.