### PR TITLE
Add Google Drive fallback for large JSON share payloads

### DIFF
--- a/src/app/api/docs/openapi.ts
+++ b/src/app/api/docs/openapi.ts
@@ -3,9 +3,9 @@ export function buildOpenApiSpec(origin: string) {
     openapi: "3.1.0",
     info: {
       title: "json-viewer API",
-      version: "1.0.0",
+      version: "1.1.0",
       description:
-        "Accepts JSON payloads and returns a shareable json-viewer URL.",
+        "Accepts JSON payloads and returns shareable json-viewer links via URL mode or Google Drive fallback.",
     },
     servers: [{ url: origin }],
     paths: {
@@ -14,62 +14,23 @@ export function buildOpenApiSpec(origin: string) {
           summary: "Create a shareable json-viewer URL",
           description:
             "Accepts JSON directly or wrapped in an envelope object with only a top-level `json` key.",
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: {
-                  anyOf: [
-                    {
-                      description: "Raw JSON payload",
-                    },
-                    {
-                      type: "object",
-                      additionalProperties: false,
-                      required: ["json"],
-                      properties: {
-                        json: {
-                          description: "JSON payload to encode",
-                        },
-                      },
-                    },
-                  ],
-                },
-                examples: {
-                  raw: {
-                    value: { hello: "world" },
-                  },
-                  envelope: {
-                    value: { json: { hello: "world" } },
-                  },
-                },
-              },
-            },
-          },
           responses: {
-            "200": {
-              description: "Shareable URL generated",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "object",
-                    required: ["url"],
-                    properties: {
-                      url: {
-                        type: "string",
-                        format: "uri",
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            "400": {
-              description: "Invalid or missing JSON payload",
-            },
-            "413": {
-              description: "Payload too large to encode in URL",
-            },
+            "200": { description: "Shareable URL generated" },
+            "400": { description: "Invalid or missing JSON payload" },
+            "413": { description: "Payload too large to encode in URL" },
+          },
+        },
+      },
+      "/api/share": {
+        post: {
+          summary: "Create a share link with URL/Drive fallback",
+          description:
+            "Supports modes: auto (default), url, and drive. Auto uses URL when small and Drive fallback when payload is large.",
+          responses: {
+            "200": { description: "Share link generated" },
+            "400": { description: "Invalid or missing JSON payload" },
+            "413": { description: "Payload too large for URL mode" },
+            "503": { description: "Drive fallback unavailable" },
           },
         },
       },

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -25,6 +25,22 @@ export function GET(request: Request) {
           },
         },
       },
+      {
+        method: "POST",
+        path: "/api/share",
+        description:
+          "Creates a share link with auto URL mode and Google Drive fallback for large payloads.",
+        requestBody: {
+          examples: [{ json: { hello: "world" }, mode: "auto" }],
+        },
+        response: {
+          example: {
+            mode: "drive",
+            slug: "gdrive:<fileId>",
+            url: `${origin}/s/gdrive:<fileId>`,
+          },
+        },
+      },
     ],
     openapi: buildOpenApiSpec(origin),
   });

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+
+import { POST } from "./route";
+
+jest.mock("@/lib/share/driveShare", () => ({
+  uploadJsonToDrive: jest.fn(),
+}));
+
+const { uploadJsonToDrive } = jest.requireMock("@/lib/share/driveShare") as {
+  uploadJsonToDrive: jest.Mock;
+};
+
+describe("POST /api/share", () => {
+  beforeEach(() => {
+    uploadJsonToDrive.mockReset();
+  });
+
+  it("returns URL mode when payload fits", async () => {
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({ json: { hello: "world" } }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("url");
+    expect(data.url).toMatch(/^https:\/\/example\.com\/\?json=/);
+  });
+
+  it("falls back to Drive in auto mode when payload is too large", async () => {
+    uploadJsonToDrive.mockResolvedValue("file-123");
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({
+        json: {
+          items: Array.from({ length: 6000 }, (_, i) => `item-${i}-${Math.sin(i).toString(36)}`),
+        },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("drive");
+    expect(data.slug).toBe("gdrive:file-123");
+    expect(data.url).toBe("https://example.com/s/gdrive:file-123");
+  });
+
+  it("returns 413 in url mode when payload is too large", async () => {
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({
+        mode: "url",
+        json: {
+          items: Array.from({ length: 6000 }, (_, i) => `item-${i}-${Math.sin(i).toString(36)}`),
+        },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(413);
+  });
+});

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+
+import {
+  JSON_QUERY_PARAM,
+  buildUrlWithQueryParam,
+  encodeJsonQueryParam,
+} from "@/components/json-viewer/utils/jsonUrlUtils";
+import { buildGDriveSlug } from "@/lib/share/shareSlug";
+import { uploadJsonToDrive } from "@/lib/share/driveShare";
+
+type ShareMode = "auto" | "url" | "drive";
+
+type ShareRequestBody =
+  | {
+      json?: unknown;
+      mode?: ShareMode;
+    }
+  | unknown;
+
+function extractJsonPayload(body: ShareRequestBody): unknown {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    !Array.isArray(body) &&
+    "json" in body &&
+    (body as { json?: unknown }).json !== undefined
+  ) {
+    return (body as { json?: unknown }).json;
+  }
+
+  return body;
+}
+
+function extractMode(body: ShareRequestBody): ShareMode {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    !Array.isArray(body) &&
+    "mode" in body &&
+    (body as { mode?: ShareMode }).mode
+  ) {
+    const mode = (body as { mode?: ShareMode }).mode;
+    if (mode === "auto" || mode === "url" || mode === "drive") {
+      return mode;
+    }
+  }
+
+  return "auto";
+}
+
+export async function POST(request: Request) {
+  let body: ShareRequestBody;
+
+  try {
+    body = (await request.json()) as ShareRequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 });
+  }
+
+  const payload = extractJsonPayload(body);
+  if (payload === undefined) {
+    return NextResponse.json(
+      { error: "Missing JSON payload. Send JSON directly or in a { \"json\": ... } field." },
+      { status: 400 },
+    );
+  }
+
+  const mode = extractMode(body);
+  const jsonText = JSON.stringify(payload);
+
+  if (mode !== "drive") {
+    const encoded = encodeJsonQueryParam(jsonText);
+    if (encoded) {
+      const requestUrl = new URL(request.url);
+      return NextResponse.json({
+        mode: "url",
+        url: buildUrlWithQueryParam(`${requestUrl.origin}/`, JSON_QUERY_PARAM, encoded),
+      });
+    }
+
+    if (mode === "url") {
+      return NextResponse.json(
+        { error: "JSON payload is too large to encode in URL. Try auto or drive mode." },
+        { status: 413 },
+      );
+    }
+  }
+
+  const driveFileId = await uploadJsonToDrive(jsonText);
+  if (!driveFileId) {
+    return NextResponse.json(
+      { error: "Google Drive fallback unavailable. Ensure server auth is configured." },
+      { status: 503 },
+    );
+  }
+
+  const requestUrl = new URL(request.url);
+  const slug = buildGDriveSlug(driveFileId);
+
+  return NextResponse.json({
+    mode: "drive",
+    slug,
+    url: `${requestUrl.origin}/s/${slug}`,
+  });
+}

--- a/src/app/s/[slug]/SharedJsonViewerPageClient.tsx
+++ b/src/app/s/[slug]/SharedJsonViewerPageClient.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "react";
+import { ReactNotificationOptions } from "react-notifications-component";
+import NavBar from "@/components/nav-bar/NavBar";
+import JsonViewer from "@/components/json-viewer/JsonViewer";
+import Notification from "@/components/notification/Notification";
+
+export default function SharedJsonViewerPageClient({ jsonText }: { jsonText: string }) {
+  const [notification, createNotification] = useState<
+    ReactNotificationOptions | undefined
+  >(undefined);
+
+  return (
+    <main className="flex h-full flex-col justify-center">
+      <NavBar createNotification={createNotification} />
+      <JsonViewer createNotification={createNotification} initialTextOverride={jsonText} />
+      <Notification notification={notification}></Notification>
+    </main>
+  );
+}

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+
+import { readJsonFromDrive } from "@/lib/share/driveShare";
+import { parseShareSlug } from "@/lib/share/shareSlug";
+import SharedJsonViewerPageClient from "./SharedJsonViewerPageClient";
+
+export default async function ShareSlugPage({ params }: { params: { slug: string } }) {
+  const parsed = parseShareSlug(params.slug);
+  if (parsed.provider !== "gdrive") {
+    notFound();
+  }
+
+  const jsonText = await readJsonFromDrive(parsed.fileId);
+  if (!jsonText) {
+    notFound();
+  }
+
+  return <SharedJsonViewerPageClient jsonText={jsonText} />;
+}

--- a/src/components/json-viewer/JsonViewer.tsx
+++ b/src/components/json-viewer/JsonViewer.tsx
@@ -21,7 +21,10 @@ import {
   MAX_QUERY_PARAM_LENGTH,
 } from "./utils/jsonUrlUtils";
 
-function JsonViewer({ createNotification }: WithNotification) {
+function JsonViewer({
+  createNotification,
+  initialTextOverride,
+}: WithNotification & { initialTextOverride?: string }) {
   type ViewType = "view" | "edit";
 
   const DEFAULT_TEXT: string = "Paste your JSON text here!";
@@ -30,7 +33,8 @@ function JsonViewer({ createNotification }: WithNotification) {
 
   const initialQueryParams = useSearchParams();
   const initialJsonQueryParam = initialQueryParams.get(JSON_QUERY_PARAM);
-  const initialText = decodeJsonQueryParam(initialJsonQueryParam) ?? DEFAULT_TEXT;
+  const initialText =
+    initialTextOverride ?? decodeJsonQueryParam(initialJsonQueryParam) ?? DEFAULT_TEXT;
 
   const [currentText, updateText] = useState(initialText);
   const [jsonObject, updateJsonObject] = useState<unknown>(undefined);

--- a/src/lib/share/driveShare.ts
+++ b/src/lib/share/driveShare.ts
@@ -1,0 +1,60 @@
+const DRIVE_UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id";
+
+function getGoogleDriveAccessToken(): string | undefined {
+  return process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+}
+
+export async function uploadJsonToDrive(jsonText: string): Promise<string | undefined> {
+  const accessToken = getGoogleDriveAccessToken();
+  if (!accessToken) {
+    return undefined;
+  }
+
+  const metadata = {
+    name: `json-viewer-${Date.now()}.json`,
+    mimeType: "application/json",
+  };
+
+  const formData = new FormData();
+  formData.append("metadata", new Blob([JSON.stringify(metadata)], { type: "application/json" }));
+  formData.append("file", new Blob([jsonText], { type: "application/json" }));
+
+  const response = await fetch(DRIVE_UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: formData,
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  const data = (await response.json()) as { id?: string };
+  return data.id;
+}
+
+export async function readJsonFromDrive(fileId: string): Promise<string | undefined> {
+  const accessToken = getGoogleDriveAccessToken();
+  if (!accessToken) {
+    return undefined;
+  }
+
+  const response = await fetch(
+    `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?alt=media`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  return response.text();
+}

--- a/src/lib/share/shareSlug.test.ts
+++ b/src/lib/share/shareSlug.test.ts
@@ -1,0 +1,15 @@
+import { buildGDriveSlug, parseShareSlug } from "./shareSlug";
+
+describe("shareSlug", () => {
+  it("builds and parses gdrive slugs", () => {
+    const slug = buildGDriveSlug("abc123");
+
+    expect(slug).toBe("gdrive:abc123");
+    expect(parseShareSlug(slug)).toEqual({ provider: "gdrive", fileId: "abc123" });
+  });
+
+  it("returns unknown for invalid slug", () => {
+    expect(parseShareSlug("foo:bar")).toEqual({ provider: "unknown" });
+    expect(parseShareSlug("gdrive:")).toEqual({ provider: "unknown" });
+  });
+});

--- a/src/lib/share/shareSlug.ts
+++ b/src/lib/share/shareSlug.ts
@@ -1,0 +1,20 @@
+export const GDRIVE_SLUG_PREFIX = "gdrive:";
+
+export function buildGDriveSlug(fileId: string): string {
+  return `${GDRIVE_SLUG_PREFIX}${fileId}`;
+}
+
+export function parseShareSlug(slug: string):
+  | { provider: "gdrive"; fileId: string }
+  | { provider: "unknown" } {
+  if (!slug.startsWith(GDRIVE_SLUG_PREFIX)) {
+    return { provider: "unknown" };
+  }
+
+  const fileId = slug.slice(GDRIVE_SLUG_PREFIX.length).trim();
+  if (!fileId) {
+    return { provider: "unknown" };
+  }
+
+  return { provider: "gdrive", fileId };
+}


### PR DESCRIPTION
- Add a new `POST /api/share` endpoint with `mode: auto|url|drive`.
- Keep URL sharing for small payloads, and fall back to Google Drive upload when payloads exceed URL limits.
- Add `gdrive:<fileId>` slug helpers and route support at `/s/[slug]`.
- Add a shared-slug page that loads Drive-backed JSON and renders it in the existing viewer UI.
- Extend API docs/OpenAPI to include the new share endpoint and fallback behavior.
- Add lean tests for auto URL vs Drive fallback and slug parsing.
- Run targeted tests:
  - `npm test -- src/app/api/share/route.test.ts src/lib/share/shareSlug.test.ts src/app/api/docs/route.test.ts src/app/openapi.json/route.test.ts`
  - `npm test -- src/app/api/json/route.test.ts src/components/json-viewer/utils/jsonUrlUtils.test.ts`
- Refs #24.
