### PR TITLE
Add API endpoints for agent-friendly JSON sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,10 @@ npm run dev
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Mui](https://mui.com/)
 
+### API
+- Docs summary: `/api/docs`
+- OpenAPI spec: `/openapi.json`
+- URL creation endpoint: `POST /api/json`
+
 ### License
 Copyright @[Jarrett Huang](https://github.com/jarretthuang), under the [MIT License](https://github.com/jarretthuang/json-viewer/blob/main/LICENSE).

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -32,16 +32,18 @@ jest.mock('react-markdown', () => ({
   default: ({ children }) => children,
 }));
 
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  }),
-});
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  });
+}

--- a/src/app/api/docs/openapi.ts
+++ b/src/app/api/docs/openapi.ts
@@ -1,0 +1,78 @@
+export function buildOpenApiSpec(origin: string) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "json-viewer API",
+      version: "1.0.0",
+      description:
+        "Accepts JSON payloads and returns a shareable json-viewer URL.",
+    },
+    servers: [{ url: origin }],
+    paths: {
+      "/api/json": {
+        post: {
+          summary: "Create a shareable json-viewer URL",
+          description:
+            "Accepts JSON directly or wrapped in an envelope object with only a top-level `json` key.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  anyOf: [
+                    {
+                      description: "Raw JSON payload",
+                    },
+                    {
+                      type: "object",
+                      additionalProperties: false,
+                      required: ["json"],
+                      properties: {
+                        json: {
+                          description: "JSON payload to encode",
+                        },
+                      },
+                    },
+                  ],
+                },
+                examples: {
+                  raw: {
+                    value: { hello: "world" },
+                  },
+                  envelope: {
+                    value: { json: { hello: "world" } },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "Shareable URL generated",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["url"],
+                    properties: {
+                      url: {
+                        type: "string",
+                        format: "uri",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid or missing JSON payload",
+            },
+            "413": {
+              description: "Payload too large to encode in URL",
+            },
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/app/api/docs/route.test.ts
+++ b/src/app/api/docs/route.test.ts
@@ -1,0 +1,26 @@
+/** @jest-environment node */
+
+import { GET } from "./route";
+
+describe("GET /api/docs", () => {
+  it("returns available API endpoints", async () => {
+    const request = new Request("https://example.com/api/docs");
+
+    const response = GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.name).toBe("json-viewer API");
+    expect(data.docs.openapi).toBe("https://example.com/openapi.json");
+    expect(data.endpoints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          method: "POST",
+          path: "/api/json",
+        }),
+      ]),
+    );
+    expect(data.openapi?.openapi).toBe("3.1.0");
+    expect(data.openapi?.paths?.["/api/json"]?.post).toBeTruthy();
+  });
+});

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { buildOpenApiSpec } from "./openapi";
+
+export function GET(request: Request) {
+  const origin = new URL(request.url).origin;
+
+  return NextResponse.json({
+    name: "json-viewer API",
+    docs: {
+      openapi: `${origin}/openapi.json`,
+    },
+    endpoints: [
+      {
+        method: "POST",
+        path: "/api/json",
+        description:
+          "Accepts any JSON payload and returns a shareable json-viewer URL.",
+        requestBody: {
+          examples: [{ hello: "world" }, { json: { hello: "world" } }],
+        },
+        response: {
+          example: {
+            url: `${origin}/?json=<compressed-json-query-param>`,
+          },
+        },
+      },
+    ],
+    openapi: buildOpenApiSpec(origin),
+  });
+}

--- a/src/app/api/json/route.test.ts
+++ b/src/app/api/json/route.test.ts
@@ -1,0 +1,87 @@
+/** @jest-environment node */
+
+import { decodeJsonQueryParam, JSON_QUERY_PARAM } from "@/components/json-viewer/utils/jsonUrlUtils";
+import { POST } from "./route";
+
+describe("POST /api/json", () => {
+  it("returns a viewer URL for raw JSON payload", async () => {
+    const request = new Request("https://example.com/api/json", {
+      method: "POST",
+      body: JSON.stringify({ hello: "world" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.url).toMatch(/^https:\/\/example\.com\/\?json=/);
+
+    const url = new URL(data.url);
+    const encoded = url.searchParams.get(JSON_QUERY_PARAM);
+
+    expect(decodeJsonQueryParam(encoded)).toBe(JSON.stringify({ hello: "world" }));
+  });
+
+  it("supports payload passed in a json field", async () => {
+    const request = new Request("https://example.com/api/json", {
+      method: "POST",
+      body: JSON.stringify({ json: { answer: 42 } }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+    const encoded = new URL(data.url).searchParams.get(JSON_QUERY_PARAM);
+
+    expect(response.status).toBe(200);
+    expect(decodeJsonQueryParam(encoded)).toBe(JSON.stringify({ answer: 42 }));
+  });
+
+  it("does not unwrap payloads that contain json plus other keys", async () => {
+    const payload = { json: { answer: 42 }, meta: "keep-me" };
+    const request = new Request("https://example.com/api/json", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+    const encoded = new URL(data.url).searchParams.get(JSON_QUERY_PARAM);
+
+    expect(response.status).toBe(200);
+    expect(decodeJsonQueryParam(encoded)).toBe(JSON.stringify(payload));
+  });
+
+  it("returns 400 when payload is invalid json", async () => {
+    const request = new Request("https://example.com/api/json", {
+      method: "POST",
+      body: "{invalid json",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 413 when payload is too large for query param", async () => {
+    const request = new Request("https://example.com/api/json", {
+      method: "POST",
+      body: JSON.stringify({
+        items: Array.from(
+          { length: 6000 },
+          (_, index) => `item-${index}-${Math.sin(index).toString(36)}`,
+        ),
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(data.error).toMatch(/too large/i);
+  });
+});

--- a/src/app/api/json/route.ts
+++ b/src/app/api/json/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+import {
+  JSON_QUERY_PARAM,
+  buildUrlWithQueryParam,
+  encodeJsonQueryParam,
+} from "@/components/json-viewer/utils/jsonUrlUtils";
+
+type JsonRequestBody =
+  | {
+      json?: unknown;
+    }
+  | unknown;
+
+function extractJsonPayload(body: JsonRequestBody): unknown {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    !Array.isArray(body) &&
+    Object.keys(body).length === 1 &&
+    "json" in body &&
+    (body as { json?: unknown }).json !== undefined
+  ) {
+    return (body as { json?: unknown }).json;
+  }
+
+  return body;
+}
+
+export async function POST(request: Request) {
+  let body: JsonRequestBody;
+
+  try {
+    body = (await request.json()) as JsonRequestBody;
+  } catch {
+    return NextResponse.json(
+      {
+        error: "Invalid JSON payload.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const payload = extractJsonPayload(body);
+
+  if (payload === undefined) {
+    return NextResponse.json(
+      {
+        error:
+          "Missing JSON payload. Send JSON directly or in a { \"json\": ... } field.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const jsonText = JSON.stringify(payload);
+  const encoded = encodeJsonQueryParam(jsonText);
+
+  if (!encoded) {
+    return NextResponse.json(
+      {
+        error:
+          "JSON payload is too large to encode in URL. Try a smaller payload.",
+      },
+      { status: 413 },
+    );
+  }
+
+  const requestUrl = new URL(request.url);
+  const viewUrl = buildUrlWithQueryParam(
+    `${requestUrl.origin}/`,
+    JSON_QUERY_PARAM,
+    encoded,
+  );
+
+  return NextResponse.json({ url: viewUrl });
+}

--- a/src/app/openapi.json/route.test.ts
+++ b/src/app/openapi.json/route.test.ts
@@ -1,0 +1,17 @@
+/** @jest-environment node */
+
+import { GET } from "./route";
+
+describe("GET /openapi.json", () => {
+  it("returns OpenAPI spec for API discovery", async () => {
+    const request = new Request("https://example.com/openapi.json");
+
+    const response = GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.openapi).toBe("3.1.0");
+    expect(data.paths?.["/api/json"]?.post).toBeTruthy();
+    expect(data.servers).toEqual([{ url: "https://example.com" }]);
+  });
+});

--- a/src/app/openapi.json/route.ts
+++ b/src/app/openapi.json/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { buildOpenApiSpec } from "@/app/api/docs/openapi";
+
+export function GET(request: Request) {
+  const origin = new URL(request.url).origin;
+
+  return NextResponse.json(buildOpenApiSpec(origin));
+}


### PR DESCRIPTION
- add POST /api/json to accept JSON payloads and return shareable viewer URLs
- add GET /api/docs with API summary plus OpenAPI discovery link
- add GET /openapi.json with an OpenAPI 3.1 spec for agent/tool discovery
- fix CI type errors by switching API routes from Response.json to NextResponse.json
- only unwrap envelope payload when json is the sole top-level key
- add and expand route tests for docs, OpenAPI discovery, and JSON payload edge cases
- fixes #30
- supersedes #32, which targeted the wrong base branch