### PR TITLE
Add custom 404 page with branded navbar

### DIFF
--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -9,8 +9,11 @@ describe("NotFound page", () => {
     expect(screen.getByText("jsonviewer.io")).toBeInTheDocument();
     expect(screen.getByAltText("JSON Viewer logo")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /more options/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /more options/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /theme:/i }),
+    ).toBeInTheDocument();
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+
+import NotFound from "./not-found";
+
+describe("NotFound page", () => {
+  test("renders app-consistent 404 content with home action", () => {
+    render(<NotFound />);
+
+    expect(screen.getByText("404")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /page not found/i }),
+    ).toBeInTheDocument();
+
+    const homeLink = screen.getByRole("link", { name: /back to home/i });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+});

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -7,7 +7,7 @@ describe("NotFound page", () => {
     render(<NotFound />);
 
     expect(screen.getByText("jsonviewer.io")).toBeInTheDocument();
-    expect(screen.getByAltText("JH")).toBeInTheDocument();
+    expect(screen.getByAltText("JSON Viewer logo")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /more options/i }),
     ).not.toBeInTheDocument();

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -8,6 +8,9 @@ describe("NotFound page", () => {
 
     expect(screen.getByText("jsonviewer.io")).toBeInTheDocument();
     expect(screen.getByAltText("JH")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /more options/i }),
+    ).not.toBeInTheDocument();
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(

--- a/src/app/not-found.test.tsx
+++ b/src/app/not-found.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from "@testing-library/react";
 import NotFound from "./not-found";
 
 describe("NotFound page", () => {
-  test("renders app-consistent 404 content with home action", () => {
+  test("renders navbar branding plus 404 content with home action", () => {
     render(<NotFound />);
+
+    expect(screen.getByText("jsonviewer.io")).toBeInTheDocument();
+    expect(screen.getByAltText("JH")).toBeInTheDocument();
 
     expect(screen.getByText("404")).toBeInTheDocument();
     expect(

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -16,7 +16,7 @@ export default function NotFound() {
       />
 
       <section className="flex w-full flex-1 p-8">
-        <div className="m-auto flex max-w-[500px] flex-col items-center rounded-3xl border border-slate-200/80 bg-powderBlue-100/10 p-12 text-center shadow-sm backdrop-blur dark:border-slate-700/40 dark:bg-powderBlue-600/20 md:rounded-2xl md:p-8">
+        <div className="m-auto flex max-w-[500px] flex-col items-center rounded-3xl p-12 text-center shadow-sm backdrop-blur md:rounded-2xl md:p-8">
           <p className="text-[40px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
             404
           </p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -9,8 +9,8 @@ export default function NotFound() {
           back: false,
           forward: false,
           share: false,
-          themeToggle: false,
-          moreOptions: false,
+          themeToggle: true,
+          moreOptions: true,
         }}
       />
 
@@ -20,8 +20,8 @@ export default function NotFound() {
         </p>
         <h1 className="mt-3 text-3xl font-bold md:text-4xl">Page not found</h1>
         <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-          The link might be broken or the page may have moved. Let&apos;s get you
-          back to the JSON viewer.
+          The link might be broken or the page may have moved. Let&apos;s get
+          you back to the JSON viewer.
         </p>
         <Link
           href="/"

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-[100svh] items-center justify-center bg-[#fdfeff] px-6 text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
+      <section className="w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
+        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+          404
+        </p>
+        <h1 className="mt-3 text-3xl font-bold md:text-4xl">Page not found</h1>
+        <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+          The link might be broken or the page may have moved. Let&apos;s get you
+          back to the JSON viewer.
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex rounded-full border border-slate-300 px-5 py-2 text-sm font-medium transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:hover:border-slate-500 dark:hover:bg-slate-800"
+        >
+          Back to home
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,8 +10,8 @@ export default function NotFound() {
           back: false,
           forward: false,
           share: false,
-          themeToggle: false,
-          moreOptions: false,
+          themeToggle: true,
+          moreOptions: true,
         }}
       />
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,9 +1,29 @@
+import Image from "next/image";
 import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="flex min-h-[100svh] items-center justify-center bg-[#fdfeff] px-6 text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
-      <section className="w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
+    <main className="min-h-[100svh] bg-[#fdfeff] text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
+      <nav className="flex h-12 items-center justify-between px-3 md:h-6">
+        <div className="flex items-center">
+          <Link href="/" aria-label="Go to JSON Viewer home" className="p-2">
+            <Image
+              src="/logoBW.png"
+              alt="JH"
+              className="rounded-full object-contain opacity-50 invert hover:opacity-60 dark:invert-0"
+              width={40}
+              height={40}
+            />
+          </Link>
+          <Link href="/" className="flex" aria-label="Go to JSON Viewer home">
+            <span className="p-1 text-[25px] font-bold opacity-50 hover:opacity-60">
+              jsonviewer.io
+            </span>
+          </Link>
+        </div>
+      </nav>
+
+      <section className="mx-auto mt-10 w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
         <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
           404
         </p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,27 +1,10 @@
-import Image from "next/image";
 import Link from "next/link";
+import NavBar from "@/components/nav-bar/NavBar";
 
 export default function NotFound() {
   return (
     <main className="min-h-[100svh] bg-[#fdfeff] text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
-      <nav className="flex h-12 items-center justify-between px-3 md:h-6">
-        <div className="flex items-center">
-          <Link href="/" aria-label="Go to JSON Viewer home" className="p-2">
-            <Image
-              src="/logoBW.png"
-              alt="JH"
-              className="rounded-full object-contain opacity-50 invert hover:opacity-60 dark:invert-0"
-              width={40}
-              height={40}
-            />
-          </Link>
-          <Link href="/" className="flex" aria-label="Go to JSON Viewer home">
-            <span className="p-1 text-[25px] font-bold opacity-50 hover:opacity-60">
-              jsonviewer.io
-            </span>
-          </Link>
-        </div>
-      </nav>
+      <NavBar showActions={false} />
 
       <section className="mx-auto mt-10 w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
         <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,4 @@
+"use client";
 import Link from "next/link";
 import NavBar from "@/components/nav-bar/NavBar";
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import NavBar from "@/components/nav-bar/NavBar";
 
 export default function NotFound() {
   return (
-    <main className="min-h-[100svh] bg-[#fdfeff] text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
+    <main className="flex min-h-[100svh] flex-col bg-[#fdfeff] text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
       <NavBar
         actionVisibility={{
           back: false,
@@ -14,21 +14,22 @@ export default function NotFound() {
         }}
       />
 
-      <section className="mx-auto mt-10 w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
-        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
-          404
-        </p>
-        <h1 className="mt-3 text-3xl font-bold md:text-4xl">Page not found</h1>
-        <p className="mt-3 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-          The link might be broken or the page may have moved. Let&apos;s get
-          you back to the JSON viewer.
-        </p>
-        <Link
-          href="/"
-          className="mt-6 inline-flex rounded-full border border-slate-300 px-5 py-2 text-sm font-medium transition hover:border-slate-400 hover:bg-slate-100 dark:border-slate-600 dark:hover:border-slate-500 dark:hover:bg-slate-800"
-        >
-          Back to home
-        </Link>
+      <section className="flex w-full flex-1 p-8">
+        <div className="m-auto flex max-w-[500px] flex-col items-center rounded-3xl border border-slate-200/80 bg-powderBlue-100/10 p-12 text-center shadow-sm backdrop-blur dark:border-slate-700/40 dark:bg-powderBlue-600/20 md:rounded-2xl md:p-8">
+          <p className="text-[40px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
+            404
+          </p>
+          <span className="text-[24px] font-semibold">Page not found</span>
+          <span className="text-[16px] text-slate-600 dark:text-slate-300">
+            The link might be broken or the page may have been removed.
+          </span>
+          <Link
+            href="/"
+            className="w-fit px-5 py-2 text-[16px] font-medium underline hover:opacity-80"
+          >
+            Back to home
+          </Link>
+        </div>
       </section>
     </main>
   );

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -4,7 +4,15 @@ import NavBar from "@/components/nav-bar/NavBar";
 export default function NotFound() {
   return (
     <main className="min-h-[100svh] bg-[#fdfeff] text-slate-950 dark:bg-[#0a0a0a] dark:text-offWhite">
-      <NavBar showActions={false} />
+      <NavBar
+        actionVisibility={{
+          back: false,
+          forward: false,
+          share: false,
+          themeToggle: false,
+          moreOptions: false,
+        }}
+      />
 
       <section className="mx-auto mt-10 w-full max-w-xl rounded-2xl border border-slate-200/80 bg-white/80 p-8 text-center shadow-sm backdrop-blur dark:border-slate-700 dark:bg-slate-900/40">
         <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -10,8 +10,8 @@ export default function NotFound() {
           back: false,
           forward: false,
           share: false,
-          themeToggle: true,
-          moreOptions: true,
+          themeToggle: false,
+          moreOptions: false,
         }}
       />
 
@@ -20,10 +20,10 @@ export default function NotFound() {
           <p className="text-[40px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
             404
           </p>
-          <span className="text-[24px] font-semibold">Page not found</span>
-          <span className="text-[16px] text-slate-600 dark:text-slate-300">
+          <h1 className="text-[24px] font-semibold">Page not found</h1>
+          <p className="text-[16px] text-slate-600 dark:text-slate-300">
             The link might be broken or the page may have been removed.
-          </span>
+          </p>
           <Link
             href="/"
             className="w-fit px-5 py-2 text-[16px] font-medium underline hover:opacity-80"

--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -3,7 +3,7 @@
 import _ from "lodash";
 import Copyright from "../copyright/Copyright";
 import Image from "next/image";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import "./NavBar.css";
 import { jsonViewerAppDescription } from "@/models/appDescriptions";
@@ -38,13 +38,16 @@ export default function NavBar({
   const [onShare, setOnShare] = useState<number | undefined>(undefined);
   const overlayRef = useRef<HTMLDivElement | null>(null);
 
-  const isActionVisible = (key: keyof NavBarActionVisibility) => {
-    if (!showActions) {
-      return false;
-    }
+  const isActionVisible = useCallback(
+    (key: keyof NavBarActionVisibility) => {
+      if (!showActions) {
+        return false;
+      }
 
-    return actionVisibility?.[key] ?? true;
-  };
+      return actionVisibility?.[key] ?? true;
+    },
+    [showActions, actionVisibility],
+  );
 
   const showAnyAction =
     isActionVisible("back") ||
@@ -87,7 +90,7 @@ export default function NavBar({
     return () => {
       window.removeEventListener("keydown", handleEscape);
     };
-  }, [expanded, showActions, actionVisibility]);
+  }, [expanded, isActionVisible]);
 
   const renderExpandedContent = () => {
     return (

--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -92,7 +92,24 @@ export default function NavBar({
   const renderExpandedContent = () => {
     return (
       <div className="content items-center overflow-hidden">
-        <span className="title w-min whitespace-nowrap">JSON Viewer</span>
+        <span className="title w-min whitespace-nowrap">JSON Viewer</span>{" "}
+        <div className="flex items-center gap-1">
+          <span>by</span>
+          <a
+            href="https://jhuang.ca"
+            target="_blank"
+            rel="noreferrer"
+            aria-label="Open JH Labs homepage"
+          >
+            <Image
+              src="/logoBW.png"
+              alt="JH"
+              className="rounded-full object-contain opacity-50 invert hover:opacity-60 dark:invert-0"
+              width={40}
+              height={40}
+            />
+          </a>
+        </div>
         <div className="inner-content overflow-auto px-10">
           <ReactMarkdown>{jsonViewerAppDescription}</ReactMarkdown>
         </div>
@@ -156,29 +173,28 @@ export default function NavBar({
     <>
       <nav className="NavBar group h-12 md:h-6" data-expanded={expanded}>
         <ul className="flex h-full w-full items-center justify-between">
-          <li className="jh-logo p-2">
+          <li className="p-2">
             <a
-              href="https://jhuang.ca"
-              target="_blank"
-              rel="noreferrer"
-              aria-label="Open JH Labs homepage"
+              href="/"
+              className="group flex items-center gap-1"
+              aria-label="Go to JSON Viewer home"
             >
               <Image
-                src="/logoBW.png"
-                alt="JH"
-                className="rounded-full object-contain opacity-50 invert hover:opacity-60 dark:invert-0"
-                width={40}
-                height={40}
+                src="/android-chrome-256x256.png"
+                alt="JSON Viewer logo"
+                className="object-contain opacity-90 group-hover:opacity-100"
+                width={30}
+                height={30}
               />
-            </a>
-            <a href="/" className="flex" aria-label="Go to JSON Viewer home">
-              <span className="p-1 text-[25px] font-bold opacity-50 hover:opacity-60">
+              <span className="text-[25px] font-bold opacity-50 group-hover:opacity-60">
                 jsonviewer.io
               </span>
             </a>
           </li>
           {showAnyAction && (
-            <li className="flex h-full justify-end p-1">{renderHeaderIcons()}</li>
+            <li className="flex h-full justify-end p-1">
+              {renderHeaderIcons()}
+            </li>
           )}
         </ul>
       </nav>

--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -14,7 +14,14 @@ import { WithNotification } from "../notification/Notification";
 import { copyTextToClipboard } from "@/utils/handleCopy";
 import ModeToggle from "@/components/theme/ModeToggle";
 
-export default function NavBar({ createNotification }: WithNotification) {
+type NavBarProps = Partial<WithNotification> & {
+  showActions?: boolean;
+};
+
+export default function NavBar({
+  createNotification,
+  showActions = true,
+}: NavBarProps) {
   const [expanded, expand] = useState(false);
   const [onShare, setOnShare] = useState<number | undefined>(undefined);
   const overlayRef = useRef<HTMLDivElement | null>(null);
@@ -29,13 +36,15 @@ export default function NavBar({ createNotification }: WithNotification) {
     }
     if (Boolean(navigator?.share)) {
       navigator.share({ url: currentUrl });
-    } else {
+    } else if (createNotification) {
       copyTextToClipboard(currentUrl, createNotification, "A shareable URL");
+    } else {
+      navigator.clipboard.writeText(currentUrl);
     }
   }, [onShare, createNotification]);
 
   useEffect(() => {
-    if (!expanded) {
+    if (!showActions || !expanded) {
       return;
     }
 
@@ -51,7 +60,7 @@ export default function NavBar({ createNotification }: WithNotification) {
     return () => {
       window.removeEventListener("keydown", handleEscape);
     };
-  }, [expanded]);
+  }, [expanded, showActions]);
 
   const renderExpandedContent = () => {
     return (
@@ -128,10 +137,12 @@ export default function NavBar({ createNotification }: WithNotification) {
               </span>
             </a>
           </li>
-          <li className="flex h-full justify-end p-1">{renderHeaderIcons()}</li>
+          {showActions && (
+            <li className="flex h-full justify-end p-1">{renderHeaderIcons()}</li>
+          )}
         </ul>
       </nav>
-      {expanded && (
+      {showActions && expanded && (
         <div
           id="navbar-expanded-panel"
           ref={overlayRef}

--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import _ from "lodash";
 import Copyright from "../copyright/Copyright";
 import Image from "next/image";

--- a/src/components/nav-bar/NavBar.tsx
+++ b/src/components/nav-bar/NavBar.tsx
@@ -14,17 +14,42 @@ import { WithNotification } from "../notification/Notification";
 import { copyTextToClipboard } from "@/utils/handleCopy";
 import ModeToggle from "@/components/theme/ModeToggle";
 
+type NavBarActionVisibility = {
+  back?: boolean;
+  forward?: boolean;
+  share?: boolean;
+  themeToggle?: boolean;
+  moreOptions?: boolean;
+};
+
 type NavBarProps = Partial<WithNotification> & {
   showActions?: boolean;
+  actionVisibility?: NavBarActionVisibility;
 };
 
 export default function NavBar({
   createNotification,
   showActions = true,
+  actionVisibility,
 }: NavBarProps) {
   const [expanded, expand] = useState(false);
   const [onShare, setOnShare] = useState<number | undefined>(undefined);
   const overlayRef = useRef<HTMLDivElement | null>(null);
+
+  const isActionVisible = (key: keyof NavBarActionVisibility) => {
+    if (!showActions) {
+      return false;
+    }
+
+    return actionVisibility?.[key] ?? true;
+  };
+
+  const showAnyAction =
+    isActionVisible("back") ||
+    isActionVisible("forward") ||
+    isActionVisible("share") ||
+    isActionVisible("themeToggle") ||
+    isActionVisible("moreOptions");
 
   useEffect(() => {
     if (!onShare) {
@@ -44,7 +69,7 @@ export default function NavBar({
   }, [onShare, createNotification]);
 
   useEffect(() => {
-    if (!showActions || !expanded) {
+    if (!isActionVisible("moreOptions") || !expanded) {
       return;
     }
 
@@ -60,7 +85,7 @@ export default function NavBar({
     return () => {
       window.removeEventListener("keydown", handleEscape);
     };
-  }, [expanded, showActions]);
+  }, [expanded, showActions, actionVisibility]);
 
   const renderExpandedContent = () => {
     return (
@@ -76,43 +101,51 @@ export default function NavBar({
   function renderHeaderIcons() {
     return (
       <>
-        <button
-          type="button"
-          className="nav-icon-button nav-mobile-hidden"
-          aria-label="Go back"
-          onClick={() => window.history.back()}
-        >
-          <ArrowBackIcon className="nav-icon" style={{ height: "85%" }} />
-        </button>
-        <button
-          type="button"
-          className="nav-icon-button nav-mobile-hidden"
-          aria-label="Go forward"
-          onClick={() => window.history.forward()}
-        >
-          <ArrowForwardIcon className="nav-icon" style={{ height: "85%" }} />
-        </button>
-        <button
-          type="button"
-          className="nav-icon-button"
-          aria-label="Share URL"
-          onClick={() => {
-            setOnShare(Date.now());
-          }}
-        >
-          <ShareIcon className="nav-icon" style={{ height: "75%" }} />
-        </button>
-        <ModeToggle />
-        <button
-          type="button"
-          className="nav-icon-button"
-          aria-label="More options"
-          aria-expanded={expanded}
-          aria-controls="navbar-expanded-panel"
-          onClick={() => expand(!expanded)}
-        >
-          <MoreHorizIcon className="nav-icon" style={{ height: "100%" }} />
-        </button>
+        {isActionVisible("back") && (
+          <button
+            type="button"
+            className="nav-icon-button nav-mobile-hidden"
+            aria-label="Go back"
+            onClick={() => window.history.back()}
+          >
+            <ArrowBackIcon className="nav-icon" style={{ height: "85%" }} />
+          </button>
+        )}
+        {isActionVisible("forward") && (
+          <button
+            type="button"
+            className="nav-icon-button nav-mobile-hidden"
+            aria-label="Go forward"
+            onClick={() => window.history.forward()}
+          >
+            <ArrowForwardIcon className="nav-icon" style={{ height: "85%" }} />
+          </button>
+        )}
+        {isActionVisible("share") && (
+          <button
+            type="button"
+            className="nav-icon-button"
+            aria-label="Share URL"
+            onClick={() => {
+              setOnShare(Date.now());
+            }}
+          >
+            <ShareIcon className="nav-icon" style={{ height: "75%" }} />
+          </button>
+        )}
+        {isActionVisible("themeToggle") && <ModeToggle />}
+        {isActionVisible("moreOptions") && (
+          <button
+            type="button"
+            className="nav-icon-button"
+            aria-label="More options"
+            aria-expanded={expanded}
+            aria-controls="navbar-expanded-panel"
+            onClick={() => expand(!expanded)}
+          >
+            <MoreHorizIcon className="nav-icon" style={{ height: "100%" }} />
+          </button>
+        )}
       </>
     );
   }
@@ -122,7 +155,12 @@ export default function NavBar({
       <nav className="NavBar group h-12 md:h-6" data-expanded={expanded}>
         <ul className="flex h-full w-full items-center justify-between">
           <li className="jh-logo p-2">
-            <a href="https://jhuang.ca" target="_blank" rel="noreferrer" aria-label="Open JH Labs homepage">
+            <a
+              href="https://jhuang.ca"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="Open JH Labs homepage"
+            >
               <Image
                 src="/logoBW.png"
                 alt="JH"
@@ -137,12 +175,12 @@ export default function NavBar({
               </span>
             </a>
           </li>
-          {showActions && (
+          {showAnyAction && (
             <li className="flex h-full justify-end p-1">{renderHeaderIcons()}</li>
           )}
         </ul>
       </nav>
-      {showActions && expanded && (
+      {isActionVisible("moreOptions") && expanded && (
         <div
           id="navbar-expanded-panel"
           ref={overlayRef}


### PR DESCRIPTION
- add a custom 404 page consistent with the app aesthetic
- reuse the shared NavBar and add per-action visibility controls
- show branding plus theme toggle and overflow menu on the 404 navbar
- remove the card border/background treatment per design tweaks
- add and update tests for 404 rendering and navbar behavior
- fixes #34