### PR TITLE
Add Google Drive fallback for large JSON share payloads

### DIFF
--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -15,8 +15,15 @@ const mockedDriveConfigured = isGoogleDriveConfigured as jest.Mock;
 const mockedUploadJsonToDrive = uploadJsonToDrive as jest.Mock;
 
 describe("POST /api/share", () => {
+  const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+  });
+
+  afterAll(() => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
   });
 
   it("returns URL mode for small payloads in auto mode", async () => {
@@ -58,7 +65,9 @@ describe("POST /api/share", () => {
 
     expect(response.status).toBe(200);
     expect(data.mode).toBe("drive");
-    expect(data.url).toBe("https://example.com/s/gdrive%3Afile-123");
+    expect(data.url).toMatch(
+      /^https:\/\/example\.com\/s\/gdrive%3Afile-123%3A[A-Za-z0-9_-]{24}$/,
+    );
     expect(mockedUploadJsonToDrive).toHaveBeenCalledTimes(1);
   });
 

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -1,0 +1,85 @@
+/** @jest-environment node */
+
+jest.mock("@/lib/share/googleDriveShare", () => ({
+  isGoogleDriveConfigured: jest.fn(),
+  uploadJsonToDrive: jest.fn(),
+}));
+
+import { POST } from "./route";
+import {
+  isGoogleDriveConfigured,
+  uploadJsonToDrive,
+} from "@/lib/share/googleDriveShare";
+
+const mockedDriveConfigured = isGoogleDriveConfigured as jest.Mock;
+const mockedUploadJsonToDrive = uploadJsonToDrive as jest.Mock;
+
+describe("POST /api/share", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns URL mode for small payloads in auto mode", async () => {
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({ json: { hello: "world" }, mode: "auto" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("url");
+    expect(data.url).toMatch(/^https:\/\/example\.com\/\?json=/);
+    expect(mockedUploadJsonToDrive).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Google Drive for large payloads in auto mode", async () => {
+    mockedDriveConfigured.mockReturnValue(true);
+    mockedUploadJsonToDrive.mockResolvedValue("file-123");
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({
+        json: {
+          items: Array.from(
+            { length: 6000 },
+            (_, index) => `item-${index}-${Math.sin(index).toString(36)}`,
+          ),
+        },
+        mode: "auto",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("drive");
+    expect(data.url).toBe("https://example.com/s/gdrive%3Afile-123");
+    expect(mockedUploadJsonToDrive).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 413 when payload is large and drive is not configured", async () => {
+    mockedDriveConfigured.mockReturnValue(false);
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({
+        json: {
+          items: Array.from(
+            { length: 6000 },
+            (_, index) => `item-${index}-${Math.sin(index).toString(36)}`,
+          ),
+        },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(413);
+  });
+});

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -117,4 +117,26 @@ describe("POST /api/share", () => {
     const decoded = encoded ? decodeJsonQueryParam(encoded) : undefined;
     expect(decoded ? JSON.parse(decoded) : undefined).toEqual(payload);
   });
+
+  it("treats {json, mode} with non-share mode as raw payload", async () => {
+    const payload = { json: { hello: "world" }, mode: "strict" };
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("url");
+
+    const encoded = new URL(data.url).searchParams.get("json");
+    expect(encoded).toBeTruthy();
+
+    const decoded = encoded ? decodeJsonQueryParam(encoded) : undefined;
+    expect(decoded ? JSON.parse(decoded) : undefined).toEqual(payload);
+  });
 });

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -10,20 +10,24 @@ import {
   isGoogleDriveConfigured,
   uploadJsonToDrive,
 } from "@/lib/share/googleDriveShare";
+import { decodeJsonQueryParam } from "@/components/json-viewer/utils/jsonUrlUtils";
 
 const mockedDriveConfigured = isGoogleDriveConfigured as jest.Mock;
 const mockedUploadJsonToDrive = uploadJsonToDrive as jest.Mock;
 
 describe("POST /api/share", () => {
   const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+  const previousShareSecret = process.env.SHARE_SLUG_SECRET;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    process.env.SHARE_SLUG_SECRET = "test-share-secret";
   });
 
   afterAll(() => {
     process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
+    process.env.SHARE_SLUG_SECRET = previousShareSecret;
   });
 
   it("returns URL mode for small payloads in auto mode", async () => {
@@ -90,5 +94,27 @@ describe("POST /api/share", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(413);
+  });
+
+  it("preserves raw objects that include a json field", async () => {
+    const payload = { json: { hello: "world" }, meta: { source: "raw" } };
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify(payload),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.mode).toBe("url");
+
+    const encoded = new URL(data.url).searchParams.get("json");
+    expect(encoded).toBeTruthy();
+
+    const decoded = encoded ? decodeJsonQueryParam(encoded) : undefined;
+    expect(decoded ? JSON.parse(decoded) : undefined).toEqual(payload);
   });
 });

--- a/src/app/api/share/route.test.ts
+++ b/src/app/api/share/route.test.ts
@@ -18,16 +18,19 @@ const mockedUploadJsonToDrive = uploadJsonToDrive as jest.Mock;
 describe("POST /api/share", () => {
   const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
   const previousShareSecret = process.env.SHARE_SLUG_SECRET;
+  const previousDriveWriteToken = process.env.SHARE_DRIVE_WRITE_TOKEN;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
     process.env.SHARE_SLUG_SECRET = "test-share-secret";
+    process.env.SHARE_DRIVE_WRITE_TOKEN = "test-drive-write-token";
   });
 
   afterAll(() => {
     process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
     process.env.SHARE_SLUG_SECRET = previousShareSecret;
+    process.env.SHARE_DRIVE_WRITE_TOKEN = previousDriveWriteToken;
   });
 
   it("returns URL mode for small payloads in auto mode", async () => {
@@ -61,7 +64,10 @@ describe("POST /api/share", () => {
         },
         mode: "auto",
       }),
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-share-drive-write-token": "test-drive-write-token",
+      },
     });
 
     const response = await POST(request);
@@ -94,6 +100,31 @@ describe("POST /api/share", () => {
     const response = await POST(request);
 
     expect(response.status).toBe(413);
+  });
+
+  it("returns 403 when drive sharing is requested without authorization", async () => {
+    mockedDriveConfigured.mockReturnValue(true);
+
+    const request = new Request("https://example.com/api/share", {
+      method: "POST",
+      body: JSON.stringify({
+        json: {
+          items: Array.from(
+            { length: 6000 },
+            (_, index) => `item-${index}-${Math.sin(index).toString(36)}`,
+          ),
+        },
+        mode: "drive",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("Google Drive sharing requires authorization.");
+    expect(mockedUploadJsonToDrive).not.toHaveBeenCalled();
   });
 
   it("preserves raw objects that include a json field", async () => {

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+
+import {
+  JSON_QUERY_PARAM,
+  buildUrlWithQueryParam,
+  encodeJsonQueryParam,
+} from "@/components/json-viewer/utils/jsonUrlUtils";
+import { buildGoogleDriveSlug } from "@/lib/share/shareSlug";
+import {
+  isGoogleDriveConfigured,
+  uploadJsonToDrive,
+} from "@/lib/share/googleDriveShare";
+
+type ShareMode = "auto" | "url" | "drive";
+
+type ShareRequestBody =
+  | {
+      json?: unknown;
+      mode?: ShareMode;
+    }
+  | unknown;
+
+function extractPayload(body: ShareRequestBody): { payload: unknown; mode: ShareMode } {
+  if (
+    typeof body === "object" &&
+    body !== null &&
+    !Array.isArray(body) &&
+    "json" in body
+  ) {
+    const parsed = body as { json?: unknown; mode?: ShareMode };
+    return {
+      payload: parsed.json,
+      mode: parsed.mode ?? "auto",
+    };
+  }
+
+  return { payload: body, mode: "auto" };
+}
+
+function buildUrlShareLink(origin: string, jsonText: string): string | null {
+  const encoded = encodeJsonQueryParam(jsonText);
+
+  if (!encoded) {
+    return null;
+  }
+
+  return buildUrlWithQueryParam(`${origin}/`, JSON_QUERY_PARAM, encoded);
+}
+
+async function buildDriveShareLink(origin: string, jsonText: string): Promise<string> {
+  const fileId = await uploadJsonToDrive(jsonText);
+  const slug = buildGoogleDriveSlug(fileId);
+  return `${origin}/s/${encodeURIComponent(slug)}`;
+}
+
+export async function POST(request: Request) {
+  let body: ShareRequestBody;
+
+  try {
+    body = (await request.json()) as ShareRequestBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload." }, { status: 400 });
+  }
+
+  const { payload, mode } = extractPayload(body);
+
+  if (payload === undefined) {
+    return NextResponse.json({ error: "Missing JSON payload." }, { status: 400 });
+  }
+
+  if (!["auto", "url", "drive"].includes(mode)) {
+    return NextResponse.json(
+      { error: 'Invalid mode. Expected one of: "auto", "url", "drive".' },
+      { status: 400 },
+    );
+  }
+
+  const requestUrl = new URL(request.url);
+  const jsonText = JSON.stringify(payload);
+
+  if (mode !== "drive") {
+    const urlLink = buildUrlShareLink(requestUrl.origin, jsonText);
+
+    if (urlLink) {
+      return NextResponse.json({ mode: "url", url: urlLink });
+    }
+
+    if (mode === "url") {
+      return NextResponse.json(
+        { error: "JSON payload is too large to encode in URL." },
+        { status: 413 },
+      );
+    }
+  }
+
+  if (!isGoogleDriveConfigured()) {
+    return NextResponse.json(
+      {
+        error:
+          "JSON payload is too large for URL sharing and Google Drive fallback is not configured.",
+      },
+      { status: 413 },
+    );
+  }
+
+  try {
+    const driveUrl = await buildDriveShareLink(requestUrl.origin, jsonText);
+    return NextResponse.json({ mode: "drive", url: driveUrl });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to create Google Drive share link." },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -21,17 +21,18 @@ type ShareRequestBody =
   | unknown;
 
 function extractPayload(body: ShareRequestBody): { payload: unknown; mode: ShareMode } {
-  if (
-    typeof body === "object" &&
-    body !== null &&
-    !Array.isArray(body) &&
-    "json" in body
-  ) {
+  if (typeof body === "object" && body !== null && !Array.isArray(body)) {
     const parsed = body as { json?: unknown; mode?: ShareMode };
-    return {
-      payload: parsed.json,
-      mode: parsed.mode ?? "auto",
-    };
+    const keys = Object.keys(parsed);
+    const isEnvelope =
+      keys.includes("json") && keys.every((key) => key === "json" || key === "mode");
+
+    if (isEnvelope) {
+      return {
+        payload: parsed.json,
+        mode: parsed.mode ?? "auto",
+      };
+    }
   }
 
   return { payload: body, mode: "auto" };

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -20,18 +20,26 @@ type ShareRequestBody =
     }
   | unknown;
 
+function isShareMode(value: unknown): value is ShareMode {
+  return value === "auto" || value === "url" || value === "drive";
+}
+
 function extractPayload(body: ShareRequestBody): { payload: unknown; mode: ShareMode } {
   if (typeof body === "object" && body !== null && !Array.isArray(body)) {
-    const parsed = body as { json?: unknown; mode?: ShareMode };
+    const parsed = body as { json?: unknown; mode?: unknown };
     const keys = Object.keys(parsed);
-    const isEnvelope =
+    const hasOnlyEnvelopeKeys =
       keys.includes("json") && keys.every((key) => key === "json" || key === "mode");
 
-    if (isEnvelope) {
-      return {
-        payload: parsed.json,
-        mode: parsed.mode ?? "auto",
-      };
+    if (hasOnlyEnvelopeKeys) {
+      const mode = parsed.mode;
+
+      if (mode === undefined || isShareMode(mode)) {
+        return {
+          payload: parsed.json,
+          mode: mode ?? "auto",
+        };
+      }
     }
   }
 
@@ -69,7 +77,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Missing JSON payload." }, { status: 400 });
   }
 
-  if (!["auto", "url", "drive"].includes(mode)) {
+  if (!isShareMode(mode)) {
     return NextResponse.json(
       { error: 'Invalid mode. Expected one of: "auto", "url", "drive".' },
       { status: 400 },

--- a/src/app/api/share/route.ts
+++ b/src/app/api/share/route.ts
@@ -20,8 +20,31 @@ type ShareRequestBody =
     }
   | unknown;
 
+const DRIVE_SHARE_WRITE_TOKEN_HEADER = "x-share-drive-write-token";
+
 function isShareMode(value: unknown): value is ShareMode {
   return value === "auto" || value === "url" || value === "drive";
+}
+
+function getDriveShareWriteToken(): string | null {
+  const token = process.env.SHARE_DRIVE_WRITE_TOKEN;
+  return token ? token.trim() : null;
+}
+
+function getDriveShareAuthorizationError(request: Request): string | null {
+  const configuredToken = getDriveShareWriteToken();
+
+  if (!configuredToken) {
+    return "Google Drive sharing is not available.";
+  }
+
+  const providedToken = request.headers.get(DRIVE_SHARE_WRITE_TOKEN_HEADER)?.trim();
+
+  if (!providedToken || providedToken !== configuredToken) {
+    return "Google Drive sharing requires authorization.";
+  }
+
+  return null;
 }
 
 function extractPayload(body: ShareRequestBody): { payload: unknown; mode: ShareMode } {
@@ -109,6 +132,15 @@ export async function POST(request: Request) {
           "JSON payload is too large for URL sharing and Google Drive fallback is not configured.",
       },
       { status: 413 },
+    );
+  }
+
+  const authorizationError = getDriveShareAuthorizationError(request);
+
+  if (authorizationError) {
+    return NextResponse.json(
+      { error: authorizationError },
+      { status: 403 },
     );
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,5 @@
-"use client";
-import JsonViewer from "@/components/json-viewer/JsonViewer";
-import NavBar from "@/components/nav-bar/NavBar";
-import { Suspense, useState } from "react";
-import { ReactNotificationOptions } from "react-notifications-component";
-import Notification from "@/components/notification/Notification";
+import AppShell from "@/components/app/AppShell";
 
 export default function App() {
-  const [notification, createNotification] = useState<
-    ReactNotificationOptions | undefined
-  >(undefined);
-
-  return (
-    <main className="flex h-full flex-col justify-center">
-      <NavBar createNotification={createNotification} />
-      <Suspense fallback={<div className="flex-1" />}>
-        <JsonViewer createNotification={createNotification}></JsonViewer>
-      </Suspense>
-      <Notification notification={notification}></Notification>
-    </main>
-  );
+  return <AppShell />;
 }

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -10,8 +10,7 @@ type ShareSlugPageProps = {
 
 export default async function ShareSlugPage({ params }: ShareSlugPageProps) {
   const { slug } = await params;
-  const decodedSlug = decodeURIComponent(slug);
-  const parsed = parseShareSlug(decodedSlug);
+  const parsed = parseShareSlug(slug);
 
   if (!parsed || parsed.provider !== "gdrive") {
     notFound();

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import { notFound } from "next/navigation";
+
+import AppShell from "@/components/app/AppShell";
+import { parseShareSlug } from "@/lib/share/shareSlug";
+import { readJsonFromDriveById } from "@/lib/share/googleDriveShare";
+
+type ShareSlugPageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+export default async function ShareSlugPage({ params }: ShareSlugPageProps) {
+  const { slug } = await params;
+  const decodedSlug = decodeURIComponent(slug);
+  const parsed = parseShareSlug(decodedSlug);
+
+  if (!parsed || parsed.provider !== "gdrive") {
+    notFound();
+  }
+
+  try {
+    const jsonText = await readJsonFromDriveById(parsed.fileId);
+    return <AppShell initialText={jsonText} />;
+  } catch {
+    notFound();
+  }
+}

--- a/src/components/app/AppShell.tsx
+++ b/src/components/app/AppShell.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { ReactNotificationOptions } from "react-notifications-component";
+
+import JsonViewer from "@/components/json-viewer/JsonViewer";
+import NavBar from "@/components/nav-bar/NavBar";
+import Notification from "@/components/notification/Notification";
+
+type AppShellProps = {
+  initialText?: string;
+};
+
+export default function AppShell({ initialText }: AppShellProps) {
+  const [notification, createNotification] = useState<
+    ReactNotificationOptions | undefined
+  >(undefined);
+
+  return (
+    <main className="flex h-full flex-col justify-center">
+      <NavBar createNotification={createNotification} />
+      <Suspense fallback={<div className="flex-1" />}>
+        <JsonViewer
+          createNotification={createNotification}
+          initialTextOverride={initialText}
+        />
+      </Suspense>
+      <Notification notification={notification} />
+    </main>
+  );
+}

--- a/src/components/json-viewer/JsonViewer.test.tsx
+++ b/src/components/json-viewer/JsonViewer.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+
+import JsonViewer from "./JsonViewer";
+import { encodeJsonQueryParam, MAX_QUERY_PARAM_LENGTH } from "./utils/jsonUrlUtils";
+
+const mockUseSearchParams = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+describe("JsonViewer", () => {
+  beforeEach(() => {
+    mockUseSearchParams.mockReturnValue({
+      get: () => null,
+    });
+  });
+
+  test("uses the server-provided initial text when there is no query payload", async () => {
+    render(
+      <JsonViewer
+        createNotification={jest.fn()}
+        initialTextOverride='{"from":"server"}'
+      />,
+    );
+
+    expect(await screen.findByLabelText(/json editor/i)).toHaveValue('{"from":"server"}');
+  });
+
+  test("prefers the query payload over the server-provided initial text", async () => {
+    const queryText = '{"from":"query"}';
+    const encodedQueryText = encodeJsonQueryParam(queryText, MAX_QUERY_PARAM_LENGTH);
+
+    mockUseSearchParams.mockReturnValue({
+      get: (key: string) => (key === "json" ? encodedQueryText : null),
+    });
+
+    render(
+      <JsonViewer
+        createNotification={jest.fn()}
+        initialTextOverride='{"from":"server"}'
+      />,
+    );
+
+    expect(await screen.findByLabelText(/json editor/i)).toHaveValue(queryText);
+  });
+});

--- a/src/components/json-viewer/JsonViewer.tsx
+++ b/src/components/json-viewer/JsonViewer.tsx
@@ -21,7 +21,11 @@ import {
   MAX_QUERY_PARAM_LENGTH,
 } from "./utils/jsonUrlUtils";
 
-function JsonViewer({ createNotification }: WithNotification) {
+type JsonViewerProps = WithNotification & {
+  initialTextOverride?: string;
+};
+
+function JsonViewer({ createNotification, initialTextOverride }: JsonViewerProps) {
   type ViewType = "view" | "edit";
 
   const DEFAULT_TEXT: string = "Paste your JSON text here!";
@@ -30,7 +34,8 @@ function JsonViewer({ createNotification }: WithNotification) {
 
   const initialQueryParams = useSearchParams();
   const initialJsonQueryParam = initialQueryParams.get(JSON_QUERY_PARAM);
-  const initialText = decodeJsonQueryParam(initialJsonQueryParam) ?? DEFAULT_TEXT;
+  const initialText =
+    initialTextOverride ?? decodeJsonQueryParam(initialJsonQueryParam) ?? DEFAULT_TEXT;
 
   const [currentText, updateText] = useState(initialText);
   const [jsonObject, updateJsonObject] = useState<unknown>(undefined);

--- a/src/components/json-viewer/JsonViewer.tsx
+++ b/src/components/json-viewer/JsonViewer.tsx
@@ -35,7 +35,7 @@ function JsonViewer({ createNotification, initialTextOverride }: JsonViewerProps
   const initialQueryParams = useSearchParams();
   const initialJsonQueryParam = initialQueryParams.get(JSON_QUERY_PARAM);
   const initialText =
-    initialTextOverride ?? decodeJsonQueryParam(initialJsonQueryParam) ?? DEFAULT_TEXT;
+    decodeJsonQueryParam(initialJsonQueryParam) ?? initialTextOverride ?? DEFAULT_TEXT;
 
   const [currentText, updateText] = useState(initialText);
   const [jsonObject, updateJsonObject] = useState<unknown>(undefined);

--- a/src/lib/share/googleDriveShare.test.ts
+++ b/src/lib/share/googleDriveShare.test.ts
@@ -1,0 +1,25 @@
+import { isGoogleDriveConfigured } from "./googleDriveShare";
+
+describe("googleDriveShare config", () => {
+  const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+  const previousShareSecret = process.env.SHARE_SLUG_SECRET;
+
+  afterEach(() => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
+    process.env.SHARE_SLUG_SECRET = previousShareSecret;
+  });
+
+  it("returns false when SHARE_SLUG_SECRET is missing", () => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    delete process.env.SHARE_SLUG_SECRET;
+
+    expect(isGoogleDriveConfigured()).toBe(false);
+  });
+
+  it("returns true when drive token and slug secret are both present", () => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    process.env.SHARE_SLUG_SECRET = "test-secret";
+
+    expect(isGoogleDriveConfigured()).toBe(true);
+  });
+});

--- a/src/lib/share/googleDriveShare.test.ts
+++ b/src/lib/share/googleDriveShare.test.ts
@@ -1,12 +1,19 @@
-import { isGoogleDriveConfigured } from "./googleDriveShare";
+import {
+  isGoogleDriveConfigured,
+  readJsonFromDriveById,
+  uploadJsonToDrive,
+} from "./googleDriveShare";
 
 describe("googleDriveShare config", () => {
   const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
   const previousShareSecret = process.env.SHARE_SLUG_SECRET;
+  const originalFetch = global.fetch;
 
   afterEach(() => {
     process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
     process.env.SHARE_SLUG_SECRET = previousShareSecret;
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
   });
 
   it("returns false when SHARE_SLUG_SECRET is missing", () => {
@@ -21,5 +28,27 @@ describe("googleDriveShare config", () => {
     process.env.SHARE_SLUG_SECRET = "test-secret";
 
     expect(isGoogleDriveConfigured()).toBe(true);
+  });
+
+  it("rejects uploads when the slug secret is missing", async () => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    delete process.env.SHARE_SLUG_SECRET;
+    global.fetch = jest.fn();
+
+    await expect(uploadJsonToDrive('{"hello":"world"}')).rejects.toThrow(
+      "Google Drive is not configured.",
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects reads when the slug secret is missing", async () => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    delete process.env.SHARE_SLUG_SECRET;
+    global.fetch = jest.fn();
+
+    await expect(readJsonFromDriveById("file-123")).rejects.toThrow(
+      "Google Drive is not configured.",
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/share/googleDriveShare.ts
+++ b/src/lib/share/googleDriveShare.ts
@@ -1,3 +1,5 @@
+import { hasShareSignatureSecret } from "./shareSignature";
+
 const DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id";
 
 function getAccessToken(): string | null {
@@ -6,7 +8,7 @@ function getAccessToken(): string | null {
 }
 
 export function isGoogleDriveConfigured(): boolean {
-  return Boolean(getAccessToken());
+  return Boolean(getAccessToken()) && hasShareSignatureSecret();
 }
 
 export async function uploadJsonToDrive(content: string): Promise<string> {
@@ -31,7 +33,7 @@ export async function uploadJsonToDrive(content: string): Promise<string> {
     "Content-Type: application/json; charset=UTF-8",
     "",
     content,
-    `--${boundary}--",
+    `--${boundary}--`,
     "",
   ].join("\r\n");
 

--- a/src/lib/share/googleDriveShare.ts
+++ b/src/lib/share/googleDriveShare.ts
@@ -1,0 +1,82 @@
+const DRIVE_UPLOAD_URL = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id";
+
+function getAccessToken(): string | null {
+  const token = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+  return token ? token.trim() : null;
+}
+
+export function isGoogleDriveConfigured(): boolean {
+  return Boolean(getAccessToken());
+}
+
+export async function uploadJsonToDrive(content: string): Promise<string> {
+  const token = getAccessToken();
+
+  if (!token) {
+    throw new Error("Google Drive is not configured.");
+  }
+
+  const boundary = `json-viewer-${Date.now()}`;
+  const metadata = {
+    name: `json-viewer-${Date.now()}.json`,
+    mimeType: "application/json",
+  };
+
+  const multipartBody = [
+    `--${boundary}`,
+    "Content-Type: application/json; charset=UTF-8",
+    "",
+    JSON.stringify(metadata),
+    `--${boundary}`,
+    "Content-Type: application/json; charset=UTF-8",
+    "",
+    content,
+    `--${boundary}--",
+    "",
+  ].join("\r\n");
+
+  const response = await fetch(DRIVE_UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+    },
+    body: multipartBody,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload to Google Drive (${response.status}).`);
+  }
+
+  const data = (await response.json()) as { id?: string };
+
+  if (!data.id) {
+    throw new Error("Google Drive upload succeeded but no file ID was returned.");
+  }
+
+  return data.id;
+}
+
+export async function readJsonFromDriveById(fileId: string): Promise<string> {
+  const token = getAccessToken();
+
+  if (!token) {
+    throw new Error("Google Drive is not configured.");
+  }
+
+  const response = await fetch(
+    `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?alt=media`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      cache: "no-store",
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to read Google Drive file (${response.status}).`);
+  }
+
+  return response.text();
+}

--- a/src/lib/share/googleDriveShare.ts
+++ b/src/lib/share/googleDriveShare.ts
@@ -11,12 +11,18 @@ export function isGoogleDriveConfigured(): boolean {
   return Boolean(getAccessToken()) && hasShareSignatureSecret();
 }
 
-export async function uploadJsonToDrive(content: string): Promise<string> {
+function getConfiguredAccessToken(): string {
   const token = getAccessToken();
 
-  if (!token) {
+  if (!token || !hasShareSignatureSecret()) {
     throw new Error("Google Drive is not configured.");
   }
+
+  return token;
+}
+
+export async function uploadJsonToDrive(content: string): Promise<string> {
+  const token = getConfiguredAccessToken();
 
   const boundary = `json-viewer-${Date.now()}`;
   const metadata = {
@@ -60,11 +66,7 @@ export async function uploadJsonToDrive(content: string): Promise<string> {
 }
 
 export async function readJsonFromDriveById(fileId: string): Promise<string> {
-  const token = getAccessToken();
-
-  if (!token) {
-    throw new Error("Google Drive is not configured.");
-  }
+  const token = getConfiguredAccessToken();
 
   const response = await fetch(
     `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?alt=media`,

--- a/src/lib/share/shareSignature.ts
+++ b/src/lib/share/shareSignature.ts
@@ -1,0 +1,54 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+const SIGNATURE_LENGTH = 24;
+
+function getShareSignatureSecret(): string | null {
+  const explicitSecret = process.env.SHARE_SLUG_SECRET?.trim();
+
+  if (explicitSecret) {
+    return explicitSecret;
+  }
+
+  const driveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN?.trim();
+  return driveToken || null;
+}
+
+function createSignature(fileId: string): string | null {
+  const secret = getShareSignatureSecret();
+
+  if (!secret) {
+    return null;
+  }
+
+  return createHmac("sha256", secret)
+    .update(fileId)
+    .digest("base64url")
+    .slice(0, SIGNATURE_LENGTH);
+}
+
+export function buildShareSignature(fileId: string): string {
+  const signature = createSignature(fileId);
+
+  if (!signature) {
+    throw new Error("Missing share slug signature secret.");
+  }
+
+  return signature;
+}
+
+export function isValidShareSignature(fileId: string, signature: string): boolean {
+  const expected = createSignature(fileId);
+
+  if (!expected || !signature) {
+    return false;
+  }
+
+  const expectedBuffer = Buffer.from(expected);
+  const signatureBuffer = Buffer.from(signature);
+
+  if (expectedBuffer.length !== signatureBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, signatureBuffer);
+}

--- a/src/lib/share/shareSignature.ts
+++ b/src/lib/share/shareSignature.ts
@@ -7,6 +7,10 @@ function getShareSignatureSecret(): string | null {
   return explicitSecret || null;
 }
 
+export function hasShareSignatureSecret(): boolean {
+  return Boolean(getShareSignatureSecret());
+}
+
 function createSignature(fileId: string): string | null {
   const secret = getShareSignatureSecret();
 

--- a/src/lib/share/shareSignature.ts
+++ b/src/lib/share/shareSignature.ts
@@ -4,13 +4,7 @@ const SIGNATURE_LENGTH = 24;
 
 function getShareSignatureSecret(): string | null {
   const explicitSecret = process.env.SHARE_SLUG_SECRET?.trim();
-
-  if (explicitSecret) {
-    return explicitSecret;
-  }
-
-  const driveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN?.trim();
-  return driveToken || null;
+  return explicitSecret || null;
 }
 
 function createSignature(fileId: string): string | null {

--- a/src/lib/share/shareSlug.test.ts
+++ b/src/lib/share/shareSlug.test.ts
@@ -1,10 +1,20 @@
 import { buildGoogleDriveSlug, parseShareSlug } from "./shareSlug";
 
 describe("shareSlug", () => {
-  it("builds and parses a gdrive slug", () => {
+  const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+
+  beforeEach(() => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+  });
+
+  afterAll(() => {
+    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
+  });
+
+  it("builds and parses a signed gdrive slug", () => {
     const slug = buildGoogleDriveSlug("abc123");
 
-    expect(slug).toBe("gdrive:abc123");
+    expect(slug).toMatch(/^gdrive:abc123:[A-Za-z0-9_-]{24}$/);
     expect(parseShareSlug(slug)).toEqual({ provider: "gdrive", fileId: "abc123" });
   });
 
@@ -14,5 +24,13 @@ describe("shareSlug", () => {
 
   it("returns null for empty gdrive id", () => {
     expect(parseShareSlug("gdrive:")).toBeNull();
+  });
+
+  it("returns null for unsigned gdrive references", () => {
+    expect(parseShareSlug("gdrive:abc123")).toBeNull();
+  });
+
+  it("returns null when signature is invalid", () => {
+    expect(parseShareSlug("gdrive:abc123:invalid-signature")).toBeNull();
   });
 });

--- a/src/lib/share/shareSlug.test.ts
+++ b/src/lib/share/shareSlug.test.ts
@@ -1,0 +1,18 @@
+import { buildGoogleDriveSlug, parseShareSlug } from "./shareSlug";
+
+describe("shareSlug", () => {
+  it("builds and parses a gdrive slug", () => {
+    const slug = buildGoogleDriveSlug("abc123");
+
+    expect(slug).toBe("gdrive:abc123");
+    expect(parseShareSlug(slug)).toEqual({ provider: "gdrive", fileId: "abc123" });
+  });
+
+  it("returns url provider for non-gdrive values", () => {
+    expect(parseShareSlug("plain-url")).toEqual({ provider: "url" });
+  });
+
+  it("returns null for empty gdrive id", () => {
+    expect(parseShareSlug("gdrive:")).toBeNull();
+  });
+});

--- a/src/lib/share/shareSlug.test.ts
+++ b/src/lib/share/shareSlug.test.ts
@@ -1,14 +1,14 @@
 import { buildGoogleDriveSlug, parseShareSlug } from "./shareSlug";
 
 describe("shareSlug", () => {
-  const previousDriveToken = process.env.GOOGLE_DRIVE_ACCESS_TOKEN;
+  const previousShareSecret = process.env.SHARE_SLUG_SECRET;
 
   beforeEach(() => {
-    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = "test-drive-token";
+    process.env.SHARE_SLUG_SECRET = "test-share-secret";
   });
 
   afterAll(() => {
-    process.env.GOOGLE_DRIVE_ACCESS_TOKEN = previousDriveToken;
+    process.env.SHARE_SLUG_SECRET = previousShareSecret;
   });
 
   it("builds and parses a signed gdrive slug", () => {

--- a/src/lib/share/shareSlug.ts
+++ b/src/lib/share/shareSlug.ts
@@ -1,4 +1,7 @@
+import { buildShareSignature, isValidShareSignature } from "./shareSignature";
+
 export const GDRIVE_SLUG_PREFIX = "gdrive:";
+const GDRIVE_SLUG_SIGNATURE_SEPARATOR = ":";
 
 export type ShareReference =
   | {
@@ -10,7 +13,8 @@ export type ShareReference =
     };
 
 export function buildGoogleDriveSlug(fileId: string): string {
-  return `${GDRIVE_SLUG_PREFIX}${fileId}`;
+  const signature = buildShareSignature(fileId);
+  return `${GDRIVE_SLUG_PREFIX}${fileId}${GDRIVE_SLUG_SIGNATURE_SEPARATOR}${signature}`;
 }
 
 export function parseShareSlug(slug: string): ShareReference | null {
@@ -18,9 +22,22 @@ export function parseShareSlug(slug: string): ShareReference | null {
     return { provider: "url" };
   }
 
-  const fileId = slug.slice(GDRIVE_SLUG_PREFIX.length).trim();
+  const rawReference = slug.slice(GDRIVE_SLUG_PREFIX.length).trim();
 
-  if (!fileId) {
+  if (!rawReference) {
+    return null;
+  }
+
+  const separatorIndex = rawReference.lastIndexOf(GDRIVE_SLUG_SIGNATURE_SEPARATOR);
+
+  if (separatorIndex <= 0 || separatorIndex === rawReference.length - 1) {
+    return null;
+  }
+
+  const fileId = rawReference.slice(0, separatorIndex).trim();
+  const signature = rawReference.slice(separatorIndex + 1).trim();
+
+  if (!fileId || !signature || !isValidShareSignature(fileId, signature)) {
     return null;
   }
 

--- a/src/lib/share/shareSlug.ts
+++ b/src/lib/share/shareSlug.ts
@@ -1,0 +1,28 @@
+export const GDRIVE_SLUG_PREFIX = "gdrive:";
+
+export type ShareReference =
+  | {
+      provider: "gdrive";
+      fileId: string;
+    }
+  | {
+      provider: "url";
+    };
+
+export function buildGoogleDriveSlug(fileId: string): string {
+  return `${GDRIVE_SLUG_PREFIX}${fileId}`;
+}
+
+export function parseShareSlug(slug: string): ShareReference | null {
+  if (!slug.startsWith(GDRIVE_SLUG_PREFIX)) {
+    return { provider: "url" };
+  }
+
+  const fileId = slug.slice(GDRIVE_SLUG_PREFIX.length).trim();
+
+  if (!fileId) {
+    return null;
+  }
+
+  return { provider: "gdrive", fileId };
+}


### PR DESCRIPTION
- Add a new `POST /api/share` endpoint with `mode: auto|url|drive` support.
- Keep URL sharing for small payloads and automatically fall back to Google Drive for oversized payloads when configured.
- Require both the Drive access token and share-slug secret before any Drive upload/read path runs.
- Require an explicit `x-share-drive-write-token` / `SHARE_DRIVE_WRITE_TOKEN` match before any Drive-backed share upload runs.
- Introduce `gdrive:<fileId>` slug helpers and add `/s/[slug]` route support to load Drive-backed shared JSON.
- Refactor the app shell slightly so slug pages can hydrate the viewer with preloaded JSON text.
- Keep locally edited `?json=` payloads authoritative after a shared-link page has already been loaded.
- Add focused tests for small-vs-large share behavior, slug parsing, incomplete Drive config, upload authorization, and shared-link hydration precedence.

Fixes #24
